### PR TITLE
fix wrong config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ docker run --rm \
 
 Open the configuration file config.toml
 ```bash
-nano /root/.sentinelnode/config.toml
+nano /home/$(whoami)/.sentinelnode/config.toml
 ```
 
 Edit the required fields (see the pink comments)
@@ -227,7 +227,7 @@ docker run --rm \
 
 Open the file wireguard.toml
 ```bash
-nano /root/.sentinelnode/wireguard.toml
+nano /home/$(whoami)/.sentinelnode/wireguard.toml
 ```
 
 Take note of the UDP port


### PR DESCRIPTION
changed the config paths in the local config of sentinel and wireguard to be that of the user 

it seems like the docker containers path is used instead.